### PR TITLE
Fixes #20 

### DIFF
--- a/apiCalls.js
+++ b/apiCalls.js
@@ -107,20 +107,14 @@ async function makeApiCall(endpoint, options = {}) {
  */
 async function authorizeApiCall(username, password) {
   const endpoint = apiEndpoints.auth.login;
-  
-  // Construct URL with parameters
   const url = new URL(endpoint);
-  const params = new URLSearchParams({
-    username: username,
-    password: password
-  });
-  url.search = params.toString();
 
   const response = await fetch(url, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
     },
+    body: new URLSearchParams({ username, password }).toString()
   });
   if (!response.ok) throw new Error('Login failed');
   


### PR DESCRIPTION
There was a prior issue with Datadis login; the login call was sent in a rather unortodox way to avoid a problem with the Datadis API. It seems that Datadis has fixes the issue on their side recentently, so it's time to refactor the api call to make it always work with any password (failed with passwords with % or & characters)